### PR TITLE
chore: add github-actions-only renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,32 @@
+// This file follows JSON5 syntax, to make it
+// easier to maintain.
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  // Disable every built-in manager (npm, dockerfile, ...) except github-actions.
+  enabledManagers: ["github-actions"],
+  // PR titles use Conventional Commits: `deps(<action>): ...`
+  semanticCommits: "enabled",
+  semanticCommitType: "deps",
+  packageRules: [
+    // GitHub Actions updates: run weekly, skip releases newer than 2 weeks
+    // to avoid picking up freshly published versions that may be unstable or
+    // compromised, and pin to full commit SHAs (with the version as a
+    // trailing comment) rather than mutable tags.
+    // When both major and minor releases exist, propose only the latest bump
+    // (typically major) instead of a separate minor PR.
+    {
+      matchManagers: ["github-actions"],
+      schedule: ["on monday"],
+      minimumReleaseAge: "14 days",
+      // Track upgrades by semver tag, but pin the resolved version to its full
+      // commit SHA (semver tag kept as a trailing comment). Use the coerced
+      // variant so short tags like `v3` / `v1.7` (which several actions only
+      // publish) still parse instead of silently stopping updates.
+      versioning: "semver-coerced",
+      pinDigests: true,
+      separateMajorMinor: false,
+      semanticCommitScope: "{{depName}}",
+      commitMessageTopic: "{{depName}}",
+    },
+  ],
+}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,9 +12,9 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -22,13 +22,13 @@ jobs:
 
       - name: Metadata
         id: meta_services
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@b2391d37b4157fa4aa2e118d643f417910ff3242 # v3
         with:
           images: ghcr.io/${{ github.repository }}
           labels: |
             org.opencontainers.image.licenses=LGPL-2.0-or-later
       - name: Build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,9 +14,9 @@ jobs:
       # Error build on warning (including clippy lints)
       RUSTFLAGS: "-Dwarnings"
     steps:
-      - uses: actions/checkout@v2
-      - uses: Swatinem/rust-cache@v1
-      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # v1
+      - uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
       - run: anvil --fork-url 'https://eth.merkle.io' --fork-block-number 20927150 &
       - run: cargo clippy
       # node should be up before running tests


### PR DESCRIPTION
Adds a github-actions-only Renovate config: weekly, 2-week-aged, SHA-pinned GitHub Actions bumps with Conventional Commit `deps(<action>):` titles.